### PR TITLE
Fixed account->info()

### DIFF
--- a/lib/Coincheck/Account.php
+++ b/lib/Coincheck/Account.php
@@ -47,7 +47,7 @@ class Account
     public function info($params = array())
     {
         $arr = array();
-        $rawResponse = $this->client->request('get', 'api/accounts/balance', $arr);
+        $rawResponse = $this->client->request('get', 'api/accounts', $arr);
         return $rawResponse;
     }
 }


### PR DESCRIPTION
`account-> balance`と同じAPIエンドポイントを使用していたので、`account-> info`は修正されました。

The Class method `account->info` is showing same data as `account->balance`. This is because `account->balance` and `account->info` point to the same API endpoint.